### PR TITLE
port to llvm10.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.4)
+project(llvm-pass-tutorial)
 
 # we need LLVM_HOME in order not automatically set LLVM_DIR
 if(NOT DEFINED ENV{LLVM_HOME})
@@ -11,5 +12,8 @@ find_package(LLVM REQUIRED CONFIG)
 add_definitions(${LLVM_DEFINITIONS})
 include_directories(${LLVM_INCLUDE_DIRS})
 link_directories(${LLVM_LIBRARY_DIRS})
+if (${LLVM_VERSION_MAJOR} VERSION_GREATER_EQUAL 10)
+    set(CMAKE_CXX_STANDARD 14)
+endif ()
 
 add_subdirectory(skeleton)  # Use your pass name here.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ and code transformation tools. We consider in this tutorial:
 - Building LLVM from source
 - Building a trivial out-of-source LLVM pass.
 
-We will be building LLVM v`7.0.0` which is the latest as of this writing.
+We will be building LLVM v`10.0.0` which is the latest as of this writing.
 We assume that you have a working compiler toolchain (GCC or LLVM) and that CMake is installed (minimum version 3.4).
 
 


### PR DESCRIPTION
When I port to LLVM10, I get some compile errors. LLVM10 use feature of C++14, so I modify CMakeLists.txt, check LLVM version and set C++ version.

```
In file included from ~/CLion_code/llvm-pass-tutorial/skeleton/Skeleton.cpp:1:
In file included from ~/pllvm/r/include/llvm/Pass.h:31:
In file included from ~/pllvm/r/include/llvm/ADT/StringRef.h:12:
~/pllvm/r/include/llvm/ADT/STLExtras.h:559:49: error: no template named 'index_sequence' in namespace 'std'
  template <size_t... Ns> value_type deref(std::index_sequence<Ns...>) const {
                                           ~~~~~^
~/pllvm/r/include/llvm/ADT/STLExtras.h:564:36: error: no template named 'index_sequence' in namespace 'std'
  decltype(iterators) tup_inc(std::index_sequence<Ns...>) const {
```